### PR TITLE
dependabot: Updated 'karma' version.

### DIFF
--- a/examples/paradas/package.json
+++ b/examples/paradas/package.json
@@ -52,7 +52,7 @@
     "cordova-plugin-whitelist": "^1.3.3",
     "jasmine-core": "~2.99.1",
     "jasmine-spec-reporter": "~4.2.1",
-    "karma": "~4.1.0",
+    "karma": "~>6.3.14",
     "karma-chrome-launcher": "~2.2.0",
     "karma-coverage-istanbul-reporter": "~2.0.1",
     "karma-jasmine": "~1.1.2",


### PR DESCRIPTION
Updated 'karma' version due to CVE-2022-0437, CVE-2022-0437,
CVE-2022-0437.